### PR TITLE
Adds server side query caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.0
 
 require (
 	github.com/grafana/grafana-plugin-sdk-go v0.212.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/snowflakedb/gosnowflake v1.8.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/hashicorp/go-hclog v1.6.2 h1:NOtoftovWkDheyUM/8JW3QMiXyxJK3uHRK7wV04n
 github.com/hashicorp/go-hclog v1.6.2/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-plugin v1.6.0 h1:wgd4KxHJTVGGqWBq4QPB1i5BZNEx9BR8+OFmHDmTk8A=
 github.com/hashicorp/go-plugin v1.6.0/go.mod h1:lBS5MtSSBZk0SHc66KACcjjlU6WzEVP/8pwz68aMkCI=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/invopop/yaml v0.2.0 h1:7zky/qH+O0DwAyoobXUqvVBwgBFRxKoQ/3FjcVpjTMY=

--- a/pkg/cache.go
+++ b/pkg/cache.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+type CacheKey struct {
+	Query           string
+	MaxDataPoints   int64
+	DurationSeconds int64
+}
+
+type CacheValue struct {
+	Tables    []DataTable
+	TimeRange backend.TimeRange
+}
+
+/**
+* Checks if the cached data is still within the allowed time range.
+ */
+func (ck *CacheKey) Expired(cached backend.TimeRange, incoming backend.TimeRange, maxTtlMinutes int) bool {
+	secondsPerBucket := ck.DurationSeconds / ck.MaxDataPoints
+	if secondsPerBucket > int64(maxTtlMinutes)*60 {
+		secondsPerBucket = int64(maxTtlMinutes) * 60
+	}
+	log.DefaultLogger.Debug("Cache compare ",
+		"it", incoming.To,
+		"ct", cached.To,
+		"if", incoming.From,
+		"cf", cached.From,
+		"secondsPerBucket", secondsPerBucket)
+	return int64(cached.To.Sub(incoming.To).Abs().Seconds()) > secondsPerBucket || int64(cached.From.Sub(incoming.From).Abs().Seconds()) > secondsPerBucket
+
+}
+
+func NewCache(maxEntries int, ttlMinutes int) *expirable.LRU[CacheKey, CacheValue] {
+	c := expirable.NewLRU[CacheKey, CacheValue](
+		maxEntries,
+		nil,
+		time.Minute*time.Duration(ttlMinutes),
+	)
+	return c
+}

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -5,9 +5,9 @@ import { SnowflakeOptions, SnowflakeSecureOptions } from './types';
 
 const { SecretFormField, FormField, Switch } = LegacyForms;
 
-interface Props extends DataSourcePluginOptionsEditorProps<SnowflakeOptions> {}
+interface Props extends DataSourcePluginOptionsEditorProps<SnowflakeOptions> { }
 
-interface State {}
+interface State { }
 
 export class ConfigEditor extends PureComponent<Props, State> {
   onAccountChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -147,6 +147,52 @@ export class ConfigEditor extends PureComponent<Props, State> {
     });
   };
 
+  onCacheEnabledChange = () => {
+    const { onOptionsChange, options } = this.props;
+    const jsonData = {
+      ...options.jsonData,
+      cacheEnabled: !options.jsonData.cacheEnabled,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
+  onMaxEntriesChange = (event: ChangeEvent<HTMLInputElement>) => {
+    this.props.onOptionsChange({
+      ...this.props.options,
+      jsonData: {
+        ...this.props.options.jsonData,
+        cacheMaxEntries: Number(event.target.value),
+      },
+    });
+  }
+
+  onTtlMinutesChange = (event: ChangeEvent<HTMLInputElement>) => {
+    this.props.onOptionsChange({
+      ...this.props.options,
+      jsonData: {
+        ...this.props.options.jsonData,
+        cacheTtlMinutes: Number(event.target.value),
+      },
+    });
+  }
+
+  componentDidMount(): void {
+    let jd = this.props.options.jsonData
+    if (!jd.account || jd.account === "") {
+      // Set default values
+      this.props.onOptionsChange({
+        ...this.props.options,
+        jsonData: {
+          ...this.props.options.jsonData,
+          cacheEnabled: true,
+          cacheMaxEntries: 1000,
+          cacheTtlMinutes: 60,
+        }
+      })
+    }
+
+  }
+
   render() {
     const { options } = this.props;
     const { jsonData, secureJsonFields } = options;
@@ -270,6 +316,29 @@ export class ConfigEditor extends PureComponent<Props, State> {
             value={jsonData.extraConfig || ''}
             placeholder="TIMESTAMP_OUTPUT_FORMAT=MM-DD-YYYY&XXXXX=yyyyy&..."
           />
+        </div>
+
+        <br />
+        <h3 className="page-heading">Cache configuration</h3>
+
+        <div className="gf-form">
+          <Switch label="Cache enabled" 
+          checked={jsonData.cacheEnabled} 
+          onChange={this.onCacheEnabledChange} />
+        </div>
+        <div className="gf-form">
+          <FormField type='number' 
+          label="Max entries" 
+          labelWidth={10} inputWidth={20} 
+          onChange={this.onMaxEntriesChange} 
+          value={jsonData.cacheMaxEntries} />
+        </div>
+        <div className="gf-form">
+          <FormField type='number' 
+          label="TTL (minutes)" 
+          labelWidth={10} inputWidth={20} 
+          onChange={this.onTtlMinutesChange} 
+          value={jsonData.cacheTtlMinutes} />
         </div>
       </div>
     );

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,7 +1,7 @@
 import defaults from 'lodash/defaults';
 
 import React, { PureComponent } from 'react';
-import { Select, TagsInput, InlineFormLabel, CodeEditor, Field, Button } from '@grafana/ui';
+import { Select, TagsInput, InlineFormLabel, CodeEditor, Field, Button, Switch } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './datasource';
 import { defaultQuery, SnowflakeOptions, SnowflakeQuery } from './types';
@@ -92,6 +92,9 @@ export class QueryEditor extends PureComponent<Props> {
             showMiniMap={false}
             onSave={() => this.props.onRunQuery()}
           />
+        </Field>
+        <Field label="Skip cache">
+          <Switch  label="Skip cache" checked={query.skipCache} onChange={() => this.props.onChange({ ...query, skipCache: !query.skipCache })} />
         </Field>
         <Field>
           <Button variant="secondary" onClick={this.onFormat}>Format</Button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,11 @@
-import { DataQuery, DataSourceJsonData } from '@grafana/data';
+import {  DataSourceJsonData } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
 
 export interface SnowflakeQuery extends DataQuery {
   queryText?: string;
   queryType?: string;
   timeColumns?: string[];
+  skipCache: boolean
 }
 
 export const defaultQuery: Partial<SnowflakeQuery> = {
@@ -27,6 +29,10 @@ export interface SnowflakeOptions extends DataSourceJsonData {
   schema?: string;
   extraConfig?: string;
   basicAuth: boolean;
+
+  cacheEnabled: boolean;
+  cacheMaxEntries: number;
+  cacheTtlMinutes: number;
 }
 
 /**


### PR DESCRIPTION
Based on the amount of datapoints and the time range we cache queries server side. You can configure the max number of items and the TTL.

Cache skipping can also be done for individual queries